### PR TITLE
Added accountBalanceDate to listAccounts request

### DIFF
--- a/nodes/FireFlyIII/Fireflyiii.node.ts
+++ b/nodes/FireFlyIII/Fireflyiii.node.ts
@@ -395,12 +395,14 @@ export class Fireflyiii implements INodeType {
 						{},
 					) as IDataObject;
 					const accountType = this.getNodeParameter('accountType', i) as string;
+					const accountBalanceDate = this.getNodeParameter('accountBalanceDate', i) as string;
 
 					const response = await fireflyApiRequest.call(this, {
 						method: 'GET',
 						endpoint: '/accounts',
 						query: {
 							type: accountType,
+							date: accountBalanceDate,
 							...paginationOptions,
 						},
 					});


### PR DESCRIPTION
The request that lists the accounts is not using the date field that allows balances to be calculated according to a date. This fix would resolve this issue.